### PR TITLE
Add missing dependencies for GH Release workflow / Linux

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -24,6 +24,12 @@ jobs:
       - name: Checkout this repo
         uses: actions/checkout@v4
 
+      - name: Install dependencies on Linux
+        if: ${{ matrix.platform.target == 'x86_64-unknown-linux-musl' }}
+        run: |
+          sudo apt-get update --yes
+          sudo apt-get install --yes musl-tools linux-libc-dev
+
       - name: Compile
         uses: houseabsolute/actions-rust-cross@v1
         with:

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -24,18 +24,16 @@ jobs:
       - name: Checkout this repo
         uses: actions/checkout@v4
 
-      - name: Install dependencies on Linux
+      - name: Install cross
         if: ${{ matrix.platform.target == 'x86_64-unknown-linux-musl' }}
-        run: |
-          sudo apt-get update --yes
-          sudo apt-get install --yes musl-tools linux-libc-dev linux-headers-generic
-          sudo ln -s /usr/include/linux /usr/include/x86_64-linux-musl/linux
+        run: cargo install cross
 
       - name: Compile
         uses: houseabsolute/actions-rust-cross@v1
         with:
           target: ${{ matrix.platform.target }}
           args: "--bin adb_cli --release"
+          force-use-cross: true
 
       - name: Upload
         uses: actions/upload-artifact@v4

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -29,6 +29,7 @@ jobs:
         run: |
           sudo apt-get update --yes
           sudo apt-get install --yes musl-tools linux-libc-dev linux-headers-generic
+          sudo ln -s /usr/include/linux /usr/include/x86_64-linux-musl/linux
 
       - name: Compile
         uses: houseabsolute/actions-rust-cross@v1

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -28,7 +28,7 @@ jobs:
         if: ${{ matrix.platform.target == 'x86_64-unknown-linux-musl' }}
         run: |
           sudo apt-get update --yes
-          sudo apt-get install --yes musl-tools linux-libc-dev
+          sudo apt-get install --yes musl-tools linux-libc-dev linux-headers-generic
 
       - name: Compile
         uses: houseabsolute/actions-rust-cross@v1

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Checkout this repo
         uses: actions/checkout@v4
 
-      - name: Install cross
+      - name: Install cross (for Linux only)
         if: ${{ matrix.platform.target == 'x86_64-unknown-linux-musl' }}
         run: cargo install cross
 
@@ -33,7 +33,7 @@ jobs:
         with:
           target: ${{ matrix.platform.target }}
           args: "--bin adb_cli --release"
-          force-use-cross: true
+          force-use-cross: ${{ matrix.platform.target == 'x86_64-unknown-linux-musl' }}
 
       - name: Upload
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Looked for a fix for the Linux target build:

- Tried adding missing dependencies for the GH Release workflow for a Linux target, and added more complete set of headers, but no joy.
- Adjusted approach to use `cross`.