### PR TITLE
Terminate interactive shell cleanly on EOF from device

### DIFF
--- a/adb_cli/src/main.rs
+++ b/adb_cli/src/main.rs
@@ -125,14 +125,15 @@ fn execute(opts: Opts) -> Result<()> {
                 {
                     let mut adb_termios = adb_termios::ADBTermios::new(std::io::stdin())?;
                     adb_termios.set_adb_termios()?;
-                    let result = device.shell(&mut std::io::stdin(), Box::new(std::io::stdout()));
+                    let result =
+                        device.shell(Box::new(std::io::stdin()), Box::new(std::io::stdout()));
                     adb_termios.restore_adb_termios()?;
                     result?;
                 }
 
                 #[cfg(not(any(target_os = "linux", target_os = "macos")))]
                 {
-                    device.shell(&mut std::io::stdin(), Box::new(std::io::stdout()))?;
+                    device.shell(Box::new(std::io::stdin()), Box::new(std::io::stdout()))?;
                 }
             } else {
                 let commands: Vec<&str> = commands.iter().map(|v| v.as_str()).collect();

--- a/adb_client/README.md
+++ b/adb_client/README.md
@@ -108,5 +108,5 @@ use adb_client::{ADBTcpDevice, ADBDeviceExt};
 let device_ip = IpAddr::V4(Ipv4Addr::new(192, 168, 0, 10));
 let device_port = 43210;
 let mut device = ADBTcpDevice::new(SocketAddr::new(device_ip, device_port)).expect("cannot find device");
-device.shell(&mut std::io::stdin(), Box::new(std::io::stdout()));
+device.shell(Box::new(std::io::stdin()), Box::new(std::io::stdout()));
 ```

--- a/adb_client/src/adb_device_ext.rs
+++ b/adb_client/src/adb_device_ext.rs
@@ -13,7 +13,7 @@ pub trait ADBDeviceExt {
 
     /// Starts an interactive shell session on the device.
     /// Input data is read from reader and write to writer.
-    fn shell(&mut self, reader: &mut dyn Read, writer: Box<(dyn Write + Send)>) -> Result<()>;
+    fn shell(&mut self, reader: Box<dyn Read + Send>, writer: Box<dyn Write + Send>) -> Result<()>;
 
     /// Display the stat information for a remote file
     fn stat(&mut self, remote_path: &str) -> Result<AdbStatResponse>;

--- a/adb_client/src/device/adb_message_device_commands.rs
+++ b/adb_client/src/device/adb_message_device_commands.rs
@@ -11,7 +11,7 @@ impl<T: ADBMessageTransport> ADBDeviceExt for ADBMessageDevice<T> {
         self.shell_command(command, output)
     }
 
-    fn shell(&mut self, reader: &mut dyn Read, writer: Box<(dyn Write + Send)>) -> Result<()> {
+    fn shell(&mut self, reader: Box<dyn Read + Send>, writer: Box<dyn Write + Send>) -> Result<()> {
         self.shell(reader, writer)
     }
 

--- a/adb_client/src/device/adb_tcp_device.rs
+++ b/adb_client/src/device/adb_tcp_device.rs
@@ -75,7 +75,7 @@ impl ADBDeviceExt for ADBTcpDevice {
     }
 
     #[inline]
-    fn shell(&mut self, reader: &mut dyn Read, writer: Box<(dyn Write + Send)>) -> Result<()> {
+    fn shell(&mut self, reader: Box<dyn Read + Send>, writer: Box<dyn Write + Send>) -> Result<()> {
         self.inner.shell(reader, writer)
     }
 

--- a/adb_client/src/device/adb_usb_device.rs
+++ b/adb_client/src/device/adb_usb_device.rs
@@ -308,7 +308,7 @@ impl ADBDeviceExt for ADBUSBDevice {
     }
 
     #[inline]
-    fn shell<'a>(&mut self, reader: &mut dyn Read, writer: Box<(dyn Write + Send)>) -> Result<()> {
+    fn shell(&mut self, reader: Box<dyn Read + Send>, writer: Box<dyn Write + Send>) -> Result<()> {
         self.inner.shell(reader, writer)
     }
 

--- a/adb_client/src/device/commands/shell.rs
+++ b/adb_client/src/device/commands/shell.rs
@@ -35,8 +35,8 @@ impl<T: ADBMessageTransport> ADBMessageDevice<T> {
     /// Input data is read from [reader] and write to [writer].
     pub(crate) fn shell(
         &mut self,
-        mut reader: &mut dyn Read,
-        mut writer: Box<(dyn Write + Send)>,
+        mut reader: Box<dyn Read + Send>,
+        mut writer: Box<dyn Write + Send>,
     ) -> Result<()> {
         self.open_session(b"shell:\0")?;
 
@@ -45,38 +45,51 @@ impl<T: ADBMessageTransport> ADBMessageDevice<T> {
         let local_id = self.get_local_id()?;
         let remote_id = self.get_remote_id()?;
 
-        // Reading thread, reads response from adbd
-        std::thread::spawn(move || -> Result<()> {
-            loop {
-                let message = transport.read_message()?;
-
-                // Acknowledge for more data
-                let response =
-                    ADBTransportMessage::new(MessageCommand::Okay, local_id, remote_id, &[]);
-                transport.write_message(response)?;
-
-                match message.header().command() {
-                    MessageCommand::Write => {
-                        writer.write_all(&message.into_payload())?;
-                        writer.flush()?;
-                    }
-                    MessageCommand::Okay => continue,
-                    _ => return Err(RustADBError::ADBShellNotSupported),
+        // Writing thread, reads from given reader (that could be stdin e.g), and writes content to device adbd.
+        // Deliberately detached: it may stay blocked reading (e.g on stdin) after the session is over,
+        // and will die with the process once this (calling) thread has returned.
+        let mut write_transport = self.get_transport().clone();
+        std::thread::spawn(move || {
+            let mut shell_writer =
+                ShellMessageWriter::new(write_transport.clone(), local_id, remote_id);
+            match std::io::copy(&mut reader, &mut shell_writer) {
+                Ok(_) => {
+                    // Reader is exhausted (e.g EOF on stdin), close our side of the session.
+                    // Device will answer with a `CLSE` message, terminating the reading loop below.
+                    let message =
+                        ADBTransportMessage::new(MessageCommand::Clse, local_id, remote_id, &[]);
+                    let _ = write_transport.write_message(message);
                 }
+                Err(e) if e.kind() == ErrorKind::BrokenPipe => (),
+                Err(e) => log::error!("Error while writing to device shell: {e}"),
             }
         });
 
-        let transport = self.get_transport().clone();
-        let mut shell_writer = ShellMessageWriter::new(transport, local_id, remote_id);
+        // Reading loop, reads response from adbd in the calling thread, so that returning from
+        // this function happens as soon as the device closes the session (EOF).
+        loop {
+            let message = transport.read_message()?;
 
-        // Read from given reader (that could be stdin e.g), and write content to device adbd
-        if let Err(e) = std::io::copy(&mut reader, &mut shell_writer) {
-            match e.kind() {
-                ErrorKind::BrokenPipe => return Ok(()),
-                _ => return Err(RustADBError::IOError(e)),
+            match message.header().command() {
+                MessageCommand::Write => {
+                    // Acknowledge for more data
+                    let response =
+                        ADBTransportMessage::new(MessageCommand::Okay, local_id, remote_id, &[]);
+                    transport.write_message(response)?;
+
+                    writer.write_all(&message.into_payload())?;
+                    writer.flush()?;
+                }
+                MessageCommand::Okay => continue,
+                MessageCommand::Clse => {
+                    // Device closed the session (EOF), acknowledge and terminate gracefully
+                    let response =
+                        ADBTransportMessage::new(MessageCommand::Clse, local_id, remote_id, &[]);
+                    let _ = transport.write_message(response);
+                    return Ok(());
+                }
+                _ => return Err(RustADBError::ADBShellNotSupported),
             }
         }
-
-        Ok(())
     }
 }

--- a/adb_client/src/server_device/adb_server_device_commands.rs
+++ b/adb_client/src/server_device/adb_server_device_commands.rs
@@ -48,8 +48,8 @@ impl ADBDeviceExt for ADBServerDevice {
 
     fn shell(
         &mut self,
-        mut reader: &mut dyn Read,
-        mut writer: Box<(dyn Write + Send)>,
+        mut reader: Box<dyn Read + Send>,
+        mut writer: Box<dyn Write + Send>,
     ) -> Result<()> {
         let supported_features = self.host_features()?;
         if !supported_features.contains(&HostFeatures::ShellV2)
@@ -65,35 +65,38 @@ impl ADBDeviceExt for ADBServerDevice {
 
         let mut write_stream = read_stream.try_clone()?;
 
-        // Reading thread, reads response from adb-server
-        std::thread::spawn(move || -> Result<()> {
-            loop {
-                let mut buffer = [0; BUFFER_SIZE];
-                match read_stream.read(&mut buffer) {
-                    Ok(0) => {
-                        read_stream.shutdown(std::net::Shutdown::Both)?;
-                        return Ok(());
-                    }
-                    Ok(size) => {
-                        writer.write_all(&buffer[..size])?;
-                        writer.flush()?;
-                    }
-                    Err(e) => {
-                        return Err(RustADBError::IOError(e));
-                    }
+        // Writing thread, reads from given reader (that could be stdin e.g), and writes content to server socket.
+        // Deliberately detached: it may stay blocked reading (e.g on stdin) after the session is over,
+        // and will die with the process once this (calling) thread has returned.
+        std::thread::spawn(move || {
+            match std::io::copy(&mut reader, &mut write_stream) {
+                Ok(_) => {
+                    // Reader is exhausted (e.g EOF on stdin), close our side of the connection
+                    let _ = write_stream.shutdown(std::net::Shutdown::Write);
                 }
+                Err(e) if e.kind() == ErrorKind::BrokenPipe => (),
+                Err(e) => log::error!("Error while writing to ADB server socket: {e}"),
             }
         });
 
-        // Read from given reader (that could be stdin e.g), and write content to server socket
-        if let Err(e) = std::io::copy(&mut reader, &mut write_stream) {
-            match e.kind() {
-                ErrorKind::BrokenPipe => return Ok(()),
-                _ => return Err(RustADBError::IOError(e)),
+        // Reading loop, reads response from adb-server in the calling thread, so that returning
+        // from this function happens as soon as the connection is closed (EOF).
+        loop {
+            let mut buffer = [0; BUFFER_SIZE];
+            match read_stream.read(&mut buffer) {
+                Ok(0) => {
+                    let _ = read_stream.shutdown(std::net::Shutdown::Both);
+                    return Ok(());
+                }
+                Ok(size) => {
+                    writer.write_all(&buffer[..size])?;
+                    writer.flush()?;
+                }
+                Err(e) => {
+                    return Err(RustADBError::IOError(e));
+                }
             }
         }
-
-        Ok(())
     }
 
     fn pull(&mut self, source: &dyn AsRef<str>, mut output: &mut dyn Write) -> Result<()> {


### PR DESCRIPTION
Fixes #2

## Problem

In the interactive shell, device responses were consumed on a detached thread while the calling thread stayed blocked on `std::io::copy(stdin, …)`. When the device closed the session (`CLSE` after typing `exit`), the reader thread returned an error and silently died — the process kept sitting on the raw-mode TTY, unkillable with Ctrl-C.

## Change

Inverts the two roles in `shell()` so that session teardown is driven by the device side:

- The **input pump** (reader → device) now runs on a detached thread. If the reader reaches EOF (e.g. piped stdin), it sends `CLSE` so the device tears the session down and answers with its own `CLSE`.
- The **device response loop** runs on the calling thread. `WRTE` payloads are written out and acknowledged with `OKAY` (previously every message was acked, including `OKAY` itself); a `CLSE` from the device is acknowledged and makes `shell()` return `Ok(())`. A transport error/EOF returns the error as before.

Returning from `shell()` lets `adb_cli` restore the terminal state and exit the process, which also reaps the detached stdin thread.

`ADBServerDevice::shell` gets the same inversion (returns on server-socket EOF).

**API note:** the `ADBDeviceExt::shell` reader parameter changes from `&mut dyn Read` to `Box<dyn Read + Send>` so the input pump can run on a detached thread. Call sites just wrap stdin in `Box::new(…)`; the `adb_client` README example is updated. The touched signatures also drop the parentheses in `Box<(dyn Write + Send)>`, which removes all six pre-existing `unused_parens` warnings.

## Verification

No Ai Pin was on hand, so this was verified against a loopback mock adbd (Python, speaks the ADB message protocol over TCP: `CNXN` → `OKAY` for `OPEN shell:` → one `WRTE` → `CLSE` after 3 s) with `adb_cli tcp 127.0.0.1:<port> shell` running under a PTY with stdin held open — the TCP path exercises the exact same `ADBMessageDevice::shell` code as USB:

- **`main`**: client prints the shell output, device sends `CLSE` at t=3 s, process is still alive at t=21 s (reproduces the reported hang).
- **this branch**: client prints the shell output, answers `CLSE`, and the process exits right at t=3 s; the mock observes the clean `CLSE` handshake followed by disconnect.

`cargo build --release` and `cargo clippy --release` are clean (six fewer warnings than `main`, none new). The USB transport itself wasn't re-tested end-to-end — that still needs a physical device, but the changed code is transport-agnostic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
